### PR TITLE
fix: defining targetDevice as const

### DIFF
--- a/bin/dev-nativescript.mjs
+++ b/bin/dev-nativescript.mjs
@@ -39,7 +39,7 @@ const getAvailableDevices = () => {
 
 const selectTargetDevice = async (devicesAvailable) => {
     if (devicesAvailable) {
-        targetDevice = await prompts({
+        const targetDevice = await prompts({
             type: 'select',
             name: 'value',
             message: 'Please choose a target device',


### PR DESCRIPTION
The variable `targetDevice` in `selectTargetDevice()` should be defined as a local const. Without it  the error `ReferenceError: targetDevice is not defined` will occur after running `dev-nativescript ios` and selecting a device.