### PR TITLE
[dev-nativescript] add target argument support

### DIFF
--- a/bin/dev-nativescript.mjs
+++ b/bin/dev-nativescript.mjs
@@ -3,7 +3,6 @@ import chokidar from 'chokidar';
 import { execSync } from 'child_process';
 import prompts  from 'prompts';
 import path  from 'path';
-import fs  from 'fs';
 
 const projectDir = process.cwd();
 const buildDir = path.resolve(

--- a/bin/dev-nativescript.mjs
+++ b/bin/dev-nativescript.mjs
@@ -14,7 +14,7 @@ const printUsageInformation = () => {
   console.log('Usage: dev-native platform [target]\n');
   console.log('Arguments:');
   console.log('   platform          ios/android\n');
-  console.log('Options:\n');
+  console.log('Options:');
   console.log('   target            specific id of target device\n\n');
 };
 

--- a/bin/dev-nativescript.mjs
+++ b/bin/dev-nativescript.mjs
@@ -7,11 +7,12 @@ import path from 'path';
 const projectDir = process.cwd();
 const buildDir = path.resolve(projectDir, 'src', 'nativescript');
 
+const program = path.basename(process.argv[1], '.mjs');
 const platform = process.argv[2];
 let targetDevice = process.argv[3] || null;
 
 const printUsageInformation = () => {
-  console.log('Usage: dev-native platform [target]\n');
+  console.log(`Usage: ${program} platform [target]\n`);
   console.log('Arguments:');
   console.log('   platform          ios/android\n');
   console.log('Options:');

--- a/bin/dev-nativescript.mjs
+++ b/bin/dev-nativescript.mjs
@@ -15,7 +15,7 @@ const printUsageInformation = () => {
   console.log('Arguments:');
   console.log('   platform          ios/android\n');
   console.log('Options:\n');
-  console.log('   target            specific id of target device\n');
+  console.log('   target            specific id of target device\n\n');
 };
 
 const getAvailableDevices = (platform) => {
@@ -78,8 +78,8 @@ const watchFiles = (platform, targetDevice) => {
 };
 (async () => {
   if (platform !== 'ios' && platform !== 'android') {
-    console.log('Please use a valid platform (ios/android)');
     printUsageInformation();
+    console.log('Please use a valid platform (ios/android)');
     return;
   }
 

--- a/bin/dev-nativescript.mjs
+++ b/bin/dev-nativescript.mjs
@@ -58,7 +58,7 @@ const runOnTarget = (platform, targetDevice) => {
 
 const watchFiles = (platform, targetDevice) => {
   buildApp();
-  runOnTarget(targetDevice);
+  runOnTarget(platform, targetDevice);
   console.log('Watching for file changes...');
 
   chokidar
@@ -95,7 +95,7 @@ const watchFiles = (platform, targetDevice) => {
   }
 
   if (targetDevice) {
-    watchFiles(targetDevice);
+    watchFiles(platform, targetDevice);
   }
 })();
 

--- a/bin/dev-nativescript.mjs
+++ b/bin/dev-nativescript.mjs
@@ -1,90 +1,101 @@
 #!/usr/bin/env node
 import chokidar from 'chokidar';
 import { execSync } from 'child_process';
-import prompts  from 'prompts';
-import path  from 'path';
+import prompts from 'prompts';
+import path from 'path';
 
 const projectDir = process.cwd();
-const buildDir = path.resolve(
-  projectDir,
-  'src',
-  'nativescript'
-);
+const buildDir = path.resolve(projectDir, 'src', 'nativescript');
+
 const platform = process.argv[2];
+let targetDevice = process.argv[3] || null;
 
+const printUsageInformation = () => {
+  console.log('Usage: dev-native platform [target]\n');
+  console.log('Arguments:');
+  console.log('   platform          ios/android\n');
+  console.log('Options:\n');
+  console.log('   target            specific id of target device\n');
+};
 
-const getAvailableDevices = () => {
-    if (platform !== 'ios' && platform !== 'android') {
-        console.log("Please use valid platform (ios/android)")
-        return;
-    } 
-    let devices = [];
-    const iosRegex = /(iOS \d+)/g;
-    const androidRegex = /(API \d+)/g;
+const getAvailableDevices = (platform) => {
+  const iosRegex = /(iOS \d+)/g;
+  const androidRegex = /(API \d+)/g;
 
-    const result = execSync(`npx cap run ${platform} --list`).toString()
-        .split('\n')
-        .filter(line => line.match(platform === 'ios' ? iosRegex : androidRegex));
+  const result = execSync(`npx cap run ${platform} --list`)
+    .toString()
+    .split('\n')
+    .filter((line) => line.match(platform === 'ios' ? iosRegex : androidRegex));
 
-    result.forEach(device => {
-        const id = device.split(" ").pop();
-        devices.push({
-            title: device,
-            value: id
-        })
-    })
-    return devices;
-}
+  return result.map((device) => {
+    const id = device.split(' ').pop();
+    return {
+      title: device,
+      value: id,
+    };
+  });
+};
 
 const selectTargetDevice = async (devicesAvailable) => {
-    if (devicesAvailable) {
-        const targetDevice = await prompts({
-            type: 'select',
-            name: 'value',
-            message: 'Please choose a target device',
-            choices: devicesAvailable,
-            initial: 0
-        });
-        return targetDevice.value;
-    }
-}
+  const targetDevice = await prompts({
+    type: 'select',
+    name: 'value',
+    message: 'Please choose a target device',
+    choices: devicesAvailable,
+    initial: 0,
+  });
+  return targetDevice.value;
+};
 
 const buildApp = () => {
-    execSync('npm run build:mobile', {stdio: 'inherit'});
-}
+  execSync('npm run build:mobile', { stdio: 'inherit' });
+};
 
-const runOnTarget = (targetDevice) => {
-    execSync(`npx cap run ${platform} --target ${targetDevice}`, {stdio: 'inherit'})
-}
+const runOnTarget = (platform, targetDevice) => {
+  execSync(`npx cap run ${platform} --target ${targetDevice}`, { stdio: 'inherit' });
+};
 
-const watchFiles = (targetDevice) => {
-    buildApp()
-    runOnTarget(targetDevice);
-    console.log("Watching for file changes...");
+const watchFiles = (platform, targetDevice) => {
+  buildApp();
+  runOnTarget(targetDevice);
+  console.log('Watching for file changes...');
 
-    chokidar.watch(`${buildDir}/**/*.ts`, {
-        interval: 100,
-        binaryInterval: 300,
-        awaitWriteFinish: {
-            stabilityThreshold: 2000,
-            pollInterval: 100
-        },
-    }).on('change', (event, path) => {
-        console.log("File change detected.");
-        buildApp()
-        runOnTarget(targetDevice);
-        console.log("Watching for file changes...");
+  chokidar
+    .watch(`${buildDir}/**/*.ts`, {
+      interval: 100,
+      binaryInterval: 300,
+      awaitWriteFinish: {
+        stabilityThreshold: 2000,
+        pollInterval: 100,
+      },
+    })
+    .on('change', (_event, _path) => {
+      console.log('File change detected.');
+      buildApp();
+      runOnTarget(platform, targetDevice);
+      console.log('Watching for file changes...');
     });
-}
+};
 (async () => {
+  if (platform !== 'ios' && platform !== 'android') {
+    console.log('Please use a valid platform (ios/android)');
+    printUsageInformation();
+    return;
+  }
 
-    let targetDevice = await selectTargetDevice(getAvailableDevices());
-    if (targetDevice) {
-        watchFiles(targetDevice);
+  if (!targetDevice) {
+    const availableDevices = getAvailableDevices(platform);
+    if (!availableDevices && availableDevices.length) {
+      console.error('Error: no available devices found');
+      return;
     }
-    
+
+    targetDevice = await selectTargetDevice(availableDevices);
+  }
+
+  if (targetDevice) {
+    watchFiles(targetDevice);
+  }
 })();
 
-export function init() {
-  
-}
+export function init() {}


### PR DESCRIPTION
To make it possible to manually choose the device id. Now it's possible to use the second argument for this. It's optional, if not provided, the list of available devices will show up to choose from.

- feat: added usage information
- feat: added `target` argument support

- refact: replaced global `platform` with function arguments
- refact: moved platform argument validation out of `getAvailableDevices` to main function

- chore: removed `fs` package, as it's unused